### PR TITLE
shebang and argument parsing improvements

### DIFF
--- a/MITObim.pl
+++ b/MITObim.pl
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 #
 # MITObim - mitochondrial baiting and iterative mapping
 # wrapper script version 1.9.1
@@ -71,9 +71,7 @@ my $USAGE = 	"\nusage: ./MITObim.pl <parameters>
 #		--insert <int>		insert size of illumina library, default=300, relevant only for proofreading
 
 
-if (scalar @ARGV < 2){
-	die "$PROGRAM\n$VERSION\n$USAGE";
-}
+
 my $command = $0;
 for (@ARGV){
        	$command .= " $_";

--- a/misc_scripts/circules.py
+++ b/misc_scripts/circules.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys,warnings
 import argparse

--- a/misc_scripts/downsample.py
+++ b/misc_scripts/downsample.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 
 """downsample

--- a/misc_scripts/get_wiggle.pl
+++ b/misc_scripts/get_wiggle.pl
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 #
 # script to extract per base coverage info for unpadded
 # assembly result from MIRA wiggle file

--- a/misc_scripts/interleave-fastqgz-MITOBIM.py
+++ b/misc_scripts/interleave-fastqgz-MITOBIM.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # encoding:utf8
 # authors: Erik Garrison, Sébastien Boisvert
 # modified by github@cypridina on 20151104 to work with MITObim


### PR DESCRIPTION
the removed test allows the --help and --version flags to work as
expected.

the change to the shebang lines allow to run the scripts on systems
where python/perl is installed in different locations